### PR TITLE
remove python-instagram dependency; call API directly.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "python-dropbox"]
 	path = python-dropbox
 	url = git@github.com:snarfed/python-dropbox.git
-[submodule "python-instagram"]
-	path = python-instagram
-	url = git@github.com:snarfed/python-instagram.git
 [submodule "requests_module"]
 	path = requests_module
 	url = git@github.com:kennethreitz/requests.git

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -48,7 +48,6 @@ for path in (
   'httplib2_module/python2',
   'oauthlib_module',
   'python-dropbox',
-  'python-instagram',
   'requests_module',
   'requests-oauthlib',
   'python-tumblpy',
@@ -60,8 +59,7 @@ for path in (
 
 import python_dropbox
 sys.modules['python_dropbox'] = python_dropbox
-import python_instagram
-sys.modules['python_instagram'] = python_instagram
+
 
 def read(filename):
   """Returns the contents of filename, or None if it doesn't exist."""

--- a/disqus.py
+++ b/disqus.py
@@ -11,7 +11,6 @@ Facebook. Differences:
   so we additionally fetch /user/details before saving
 - Deny appears to be broken on Disqus's side (clicking "No Thanks" has
   no effect), so we ignore that possibility for now.
-- InstagramAuth provides a python_instagram API.
 
 TODO unify Disqus, Facebook, and Instagram
 """

--- a/handlers.py
+++ b/handlers.py
@@ -15,7 +15,6 @@ import urllib
 
 import apiclient
 from oauth2client.client import AccessTokenRefreshError
-from python_instagram.bind import InstagramAPIError
 import requests
 import urllib2
 import webapp2
@@ -161,7 +160,6 @@ def interpret_http_exception(exception):
     exc: one of:
       apiclient.errors.HttpError
       exc.WSGIHTTPException
-      InstagramAPIError
       oauth2client.client.AccessTokenRefreshError
       requests.HTTPError
       urllib2.HTTPError
@@ -195,15 +193,12 @@ def interpret_http_exception(exception):
     code = e.resp.status
     body = e.content
 
-  elif isinstance(e, InstagramAPIError):
-    if e.error_type in ('OAuthAccessTokenException',        # revoked access
-                        'APIRequiresAuthenticationError'):  # account deleted
-      code = '401'
-    else:
-      code = e.status_code
-    body = '%s: %s' % (e.error_type, e.error_message)
-
   elif isinstance(e, AccessTokenRefreshError) and str(e) == 'invalid_grant':
+    code = '401'
+
+  # instagram-specific error_types that should disable the source.
+  if body and ('OAuthAccessTokenException' in body            # revoked access
+               or 'APIRequiresAuthenticationError' in body):  # account deleted
     code = '401'
 
   if code:

--- a/python_instagram
+++ b/python_instagram
@@ -1,1 +1,0 @@
-python-instagram/instagram


### PR DESCRIPTION
some instagram-specific changes to interpret_http_exception:

when error body contains specific types that mean the access token was
revoked or the account was deleted, change the error code to 401 to
tell Bridgy that the source should be disabled.

note that there was a small regression here when we stopped using the
python-instagram library. instagram errors previously were
reformatted as: "error_type: error_message". this version will
simply give back the unformatted json blob, so instead of

  OAuthAccessTokenException: The access_token provided is invalid.

we get:

  {"meta":{"error_type":"OAuthAccessTokenException","code":400,
   "error_message":"The access_token provided is invalid."}}