### PR TITLE
Flickr add upload method

### DIFF
--- a/oauth_dropins/flickr.py
+++ b/oauth_dropins/flickr.py
@@ -26,6 +26,7 @@ from webob import exc
 
 REQUEST_TOKEN_URL = 'https://www.flickr.com/services/oauth/request_token'
 AUTHORIZE_URL = 'https://www.flickr.com/services/oauth/authorize'
+AUTHENTICATE_URL = 'https://www.flickr.com/services/oauth/authenticate'
 ACCESS_TOKEN_URL = 'https://www.flickr.com/services/oauth/access_token'
 API_URL = 'https://api.flickr.com/services/rest'
 
@@ -103,10 +104,16 @@ class StartHandler(handlers.StartHandler):
       token_secret=resource_owner_secret,
       state=state).put()
 
-    auth_url = AUTHORIZE_URL + '?' + urllib.urlencode({
-      'perms': self.request.get('perms', 'read'),
-      'oauth_token': resource_owner_key
-    })
+    if self.scope:
+      auth_url = AUTHORIZE_URL + '?' + urllib.urlencode({
+        'perms': self.scope or 'read',
+        'oauth_token': resource_owner_key
+      })
+    else:
+      auth_url = AUTHENTICATE_URL + '?' + urllib.urlencode({
+        'oauth_token': resource_owner_key
+      })
+
     logging.info(
       'Generated request token, redirect to Flickr authorization url: %s',
       auth_url)

--- a/oauth_dropins/flickr_auth.py
+++ b/oauth_dropins/flickr_auth.py
@@ -91,7 +91,7 @@ def call_api_method(method, params, token_key, token_secret):
   return body
 
 
-def upload(params, photo_file, token_key, token_secret, timeout=None):
+def upload(params, photo_file, token_key, token_secret):
   """Upload a photo to this user's Flickr account.
 
   Flickr uploads use their own API endpoint, that returns only XML.
@@ -113,9 +113,6 @@ def upload(params, photo_file, token_key, token_secret, timeout=None):
     requests.HTTPError on http error or urllib2.HTTPError if we get a
     stat='fail' response from Flickr.
   """
-  if not timeout:
-    timeout = appengine_config.HTTP_TIMEOUT
-
   upload_url = 'https://up.flickr.com/services/upload'
   auth = requests_oauthlib.OAuth1(
       client_key=appengine_config.FLICKR_APP_KEY,
@@ -134,7 +131,7 @@ def upload(params, photo_file, token_key, token_secret, timeout=None):
   logging.debug('uploading with data: %s', data)
   resp = requests.post(upload_url, data=data, files={
     'photo': photo_file,
-  }, timeout=timeout)
+  }, timeout=appengine_config.HTTP_TIMEOUT)
   logging.debug('upload response: %s, %s', resp, resp.content)
   resp.raise_for_status()
 


### PR DESCRIPTION
- Flickr uploads uses a separate API from other requests
- use requests.post for upload (urllib2 doesn't help with multi-part)
- If no permission scopes are requested, use the authenticate
  API instead of authorize (returns without prompting if previous authed)