### PR TITLE
Fix: Don't add the `state` parameter into the `redirect_uri`

### DIFF
--- a/oauth_dropins/meetup.py
+++ b/oauth_dropins/meetup.py
@@ -98,7 +98,7 @@ class StartHandler(handlers.StartHandler):
 
         return GET_AUTH_CODE_URL % {
                 'client_id': MEETUP_CLIENT_ID,
-                'redirect_uri': urllib.parse.quote_plus(self.to_url(state=state)),
+                'redirect_uri': urllib.parse.quote_plus(self.to_url()),
                 'scope': self.scope,
                 'state': '%s|%s' % (state, csrf_key.id()),
                 }

--- a/oauth_dropins/meetup.py
+++ b/oauth_dropins/meetup.py
@@ -100,7 +100,7 @@ class StartHandler(handlers.StartHandler):
                 'client_id': MEETUP_CLIENT_ID,
                 'redirect_uri': urllib.parse.quote_plus(self.to_url()),
                 'scope': self.scope,
-                'state': '%s|%s' % (state, csrf_key.id()),
+                'state': '%s|%s' % (urllib.parse.quote_plus(state), csrf_key.id()),
                 }
 
     @classmethod


### PR DESCRIPTION
This was an accident - the `state` will be automagically returned as
part of the code flow.