### PR TITLE
Adding access to praw API for use in granary

### DIFF
--- a/oauth_dropins/handlers.py
+++ b/oauth_dropins/handlers.py
@@ -209,7 +209,9 @@ class CallbackHandler(BaseHandler):
                      ('access_token_secret', token[1])]
       except NotImplementedError:
         logging.info('access_token() not implemented')
-
+      token = auth_entity.refresh_token
+      params.append(('refresh_token', token))
+      
     url = util.add_query_params(self.to_path, params)
     logging.info('Finishing OAuth flow: redirecting to %s', url)
     self.redirect(url)

--- a/oauth_dropins/handlers.py
+++ b/oauth_dropins/handlers.py
@@ -209,9 +209,12 @@ class CallbackHandler(BaseHandler):
                      ('access_token_secret', token[1])]
       except NotImplementedError:
         logging.info('access_token() not implemented')
-      token = auth_entity.refresh_token
-      params.append(('refresh_token', token))
-      
+      try:
+        token = auth_entity.refresh_token
+        params.append(('refresh_token', token))
+      except AttributeError:
+        logging.info('refresh_token not included')
+
     url = util.add_query_params(self.to_path, params)
     logging.info('Finishing OAuth flow: redirecting to %s', url)
     self.redirect(url)

--- a/oauth_dropins/reddit.py
+++ b/oauth_dropins/reddit.py
@@ -42,7 +42,7 @@ class RedditAuth(models.BaseAuth):
   user_json = ndb.TextProperty()
 
   def site_name(self):
-    return 'reddit'
+    return 'Reddit'
 
   def user_display_name(self):
     """Returns the username.
@@ -55,6 +55,7 @@ class StartHandler(handlers.StartHandler):
   """
   NAME = 'reddit'
   LABEL = 'Reddit'
+  DEFAULT_SCOPE = 'identity,read'
 
   def redirect_url(self, state=None):
     # if state is None the reddit API redirect breaks, set to random string
@@ -72,7 +73,7 @@ class StartHandler(handlers.StartHandler):
                              token_secret=state,
                              state=state).put()
     st = util.encode_oauth_state({'state':state,'to_path':self.to_path})
-    return reddit.auth.url(['identity','read'], st, 'permanent')
+    return reddit.auth.url(self.scope.split(self.SCOPE_SEPARATOR), st, 'permanent')
 
   @classmethod
   def button_html(cls, *args, **kwargs):

--- a/oauth_dropins/reddit.py
+++ b/oauth_dropins/reddit.py
@@ -41,6 +41,21 @@ class RedditAuth(models.BaseAuth):
   refresh_token = ndb.StringProperty(required=True)
   user_json = ndb.TextProperty()
 
+  def api(self):
+    if self.refresh_token:
+      r = praw.Reddit(client_id=REDDIT_APP_KEY,
+                           client_secret=REDDIT_APP_SECRET,
+                           refresh_token=self.refresh_token,
+                           user_agent='oauth-dropin reddit api')
+      rt = reddit.auth.authorize(code)
+      if rt:
+        self.refresh_token = rt
+    else:
+      r = praw.Reddit(client_id=REDDIT_APP_KEY,
+                           client_secret=REDDIT_APP_SECRET,
+                           user_agent='oauth-dropin reddit api')
+    return r
+    
   def site_name(self):
     return 'reddit'
 

--- a/oauth_dropins/reddit.py
+++ b/oauth_dropins/reddit.py
@@ -40,7 +40,7 @@ class RedditAuth(models.BaseAuth):
   # refresh token
   refresh_token = ndb.StringProperty(required=True)
   user_json = ndb.TextProperty()
-    
+
   def site_name(self):
     return 'reddit'
 
@@ -117,8 +117,7 @@ class CallbackHandler(handlers.CallbackHandler):
     # a short list of attributes to grab, for more info on attributes see:
     # https://github.com/praw-dev/praw/blob/master/praw/models/reddit/redditor.py#L41
     # calling json_dumps on the user object opens some kind of stream
-    attribute_list = ['name',
-                      'comment_karma',
+    attribute_list = ['comment_karma',
                       'created_utc',
                       'id',
                       'name',

--- a/oauth_dropins/reddit.py
+++ b/oauth_dropins/reddit.py
@@ -131,9 +131,3 @@ class CallbackHandler(handlers.CallbackHandler):
                       user_json=json_dumps(user_json))
     auth.put()
     self.finish(auth, state=st)
-
-def get_reddit_api(refresh_token):
-  return praw.Reddit(client_id=REDDIT_APP_KEY,
-                     client_secret=REDDIT_APP_SECRET,
-                     refresh_token=refresh_token,
-                     user_agent='oauth-dropin reddit api')


### PR DESCRIPTION
A few small updates to make it compatible with my PR for granary https://github.com/snarfed/granary/pull/197.

I figured this would be the easiest place to instantiate the praw API so that the package isn't a dependency for both oauth-dropin and granary.  I also realized that I need to have a way to pass around the refresh_token so that callback handlers can make use of it.  However, that doesn't appear to be working but I don't understand why (see comment in https://github.com/snarfed/granary/pull/197)

Also, updated the user_agent to extend beyond identity checking since it does reading too now.