### PR TITLE
returning original state dict

### DIFF
--- a/oauth_dropins/reddit.py
+++ b/oauth_dropins/reddit.py
@@ -123,7 +123,7 @@ class CallbackHandler(handlers.CallbackHandler):
                       refresh_token=refresh_token,
                       user_json=json_dumps(user_json))
     auth.put()
-    self.finish(auth, state=st)
+    self.finish(auth, state=state)
 
 def praw_to_user(user):
   return {


### PR DESCRIPTION
I realized that bridgy requires the originally state dictionary from it's request in the response. I was returning a modified state dictionary.